### PR TITLE
リログ時にアイテムが消える問題を修正

### DIFF
--- a/src/main/java/schr0/chastmob/inventory/InventoryChast.java
+++ b/src/main/java/schr0/chastmob/inventory/InventoryChast.java
@@ -47,10 +47,10 @@ public abstract class InventoryChast extends InventoryBasic
 	{
 		this.clear();
 
-		for (int slot = 0; slot < nbtList.tagCount(); ++slot)
+		for (int i = 0; i < nbtList.tagCount(); ++i)
 		{
-			NBTTagCompound nbt = nbtList.getCompoundTagAt(slot);
-			slot = nbt.getByte("Slot") & 255;
+			NBTTagCompound nbt = nbtList.getCompoundTagAt(i);
+			int slot = nbt.getByte("Slot") & 255;
 
 			if ((0 <= slot) && (slot < this.getSizeInventory()))
 			{


### PR DESCRIPTION
![アイテムが消滅](https://i.gyazo.com/2179d42675829700a016fd77efa0a871.gif)

インベントリに隙間がある状態でリログをした際に、アイテムが消滅します。
このプルリクエストにはこのバグの修正が含まれています。

よろしくお願いします。